### PR TITLE
Cyclic arguments support

### DIFF
--- a/test/spec/lib/matchers.jasmine.js
+++ b/test/spec/lib/matchers.jasmine.js
@@ -2,7 +2,7 @@
 
 beforeEach(function () {
 
-  this.addMatchers({
+  jasmine.addMatchers({
     toEqualData: function (expected) {
       return angular.equals(this.actual, expected);
     },

--- a/test/spec/modules/tada-testing-controller.spec.js
+++ b/test/spec/modules/tada-testing-controller.spec.js
@@ -110,6 +110,39 @@ describe('Testing tada lib', function () {
 
   });
 
+  describe('Cyclic arguments', function () {
+    var cycle = [];
+    cycle.push(cycle);
+    
+    describe('Synced method', function () {
+      it('should support cyclic arguments in mock', function () {
+        expect(function () {
+          demoService.syncedMethod(cycle)
+        }).not.toThrow();
+      });
+
+      it('should support cyclic arguments for whenCalledWithArgs', function () {
+        expect(function () {
+          demoService.syncedMethod.whenCalledWithArgs(cycle);
+        }).not.toThrow();
+      });
+    });
+    
+    describe('Ansynced method', function () {
+      it('should support cyclic arguments in mock', function () {
+        expect(function () {
+          demoService.asyncServiceMethod(cycle)
+        }).not.toThrow();
+      });
+
+      it('should support cyclic arguments for whenCalledWithArgs', function () {
+        expect(function () {
+          demoService.asyncServiceMethod.whenCalledWithArgs(cycle);
+        }).not.toThrow();
+      });
+    });
+  });
+
   function aDemoController() {
     var ctrl;
     inject(function ($controller, $rootScope) {


### PR DESCRIPTION
PhantomJS guards against Cyclic arguments for `JSON.stringify`. Making it hard to compare jquery elements
https://github.com/ariya/phantomjs/issues/11206
